### PR TITLE
遷移先をPrefixでの指定に変更

### DIFF
--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -16,10 +16,10 @@
 <% if user_signed_in? && current_user.id == @tweet.user_id %>
   <ul>
     <li>
-      <%= link_to "編集", "/tweets/#{@tweet.id}/edit" %>
+      <%= link_to "編集", edit_tweet_path(@tweet.id) %>
     </li>
         <li>
-      <%= link_to '削除', tweet_path(@tweet.id), method: :delete %>
+      <%= link_to "削除", tweet_path(@tweet.id), method: :delete %>
     </li>
   </ul>
 <% end %>


### PR DESCRIPTION
#What
投稿編集ボタンの遷移先をURI PatternからPrefixでの指定に変更

#Why
他ボタンとの統一化の為